### PR TITLE
Fix #93 review findings: debate flow, worktree deps, command markers

### DIFF
--- a/.claude/commands/ask-gemini.md
+++ b/.claude/commands/ask-gemini.md
@@ -1,5 +1,8 @@
 # Ask Gemini - Automated AI Peer Review (Gemini)
 
+**Use this when:** Getting a structured second opinion from Gemini via a 3-round debate, on a plan, code change, branch, or feature.
+**Don't use this when:** You want a first-pass code review (use `/review-code`), or you want to evaluate findings from a prior debate (use `/peer-review`).
+
 You are the Lead Reviewer. Your job is to get a second opinion from Gemini on the user's work, engage in a constructive debate, and produce actionable recommendations.
 
 <procedure>

--- a/.claude/commands/ask-gemini.md
+++ b/.claude/commands/ask-gemini.md
@@ -32,7 +32,7 @@ Save all gathered context to a temporary file:
 
 **Read** `/tmp/ask-gemini-context.md` first (ignore the error if it doesn't exist), then **Write** the gathered context to it.
 
-## Step 3: Get Initial Review from Gemini
+## Step 3: Get Initial Review and Seed the Debate File
 
 Run the ask-gemini script to get Gemini's initial review:
 
@@ -40,17 +40,27 @@ Run the ask-gemini script to get Gemini's initial review:
 node .claude/scripts/ask-gemini.js review --context-file /tmp/ask-gemini-context.md --review-type [plan|code|branch|feature]
 ```
 
-Read the script output. In the next step, you'll respond to this review as the author.
+The cumulative debate file `/tmp/ask-gemini-debate.md` is built incrementally: every script call and every Claude turn gets appended to it BEFORE the next step runs. This way each `respond` call sees the full prior transcript.
+
+**Read** `/tmp/ask-gemini-debate.md` first (ignore the error if it does not exist - this is a fresh debate). Then **Write** the file with the script's output under this heading:
+
+```markdown
+## Gemini (Initial Review):
+
+[STDOUT FROM THE REVIEW SCRIPT]
+```
+
+Read the saved review yourself - the next step is responding to it as the author.
 
 If the script fails, show the error to the user. Common issues: missing API key in `.env.local` or environment variables, network errors, rate limits. Do not retry automatically.
 
 ## Step 4: Debate Cycle (Repeat 3 Times)
 
-For each debate cycle:
+For each debate cycle (rounds 1, 2, and 3):
 
 ### 4a. Respond to Gemini's Feedback
 
-As the author, respond to Gemini's review using this structure:
+As the author, draft a response using this structure:
 
 ```markdown
 ## Accepted
@@ -63,11 +73,9 @@ Points where I have a different perspective (with reasoning)
 Clarifications needed from the reviewer
 ```
 
-### 4b. Save the Debate History
+### 4b. Append Your Response to the Debate File
 
-Append your response to a debate file:
-
-Save each round to its own file: `/tmp/ask-gemini-round-N.md` (e.g., `/tmp/ask-gemini-round-1.md`). **Read** the target file first (ignore the error if it doesn't exist), then **Write** it:
+**Read** `/tmp/ask-gemini-debate.md` first, then **Write** the file with your response appended at the end under this heading (where N is the current round number):
 
 ```markdown
 ## Claude (Round N):
@@ -75,19 +83,31 @@ Save each round to its own file: `/tmp/ask-gemini-round-N.md` (e.g., `/tmp/ask-g
 [YOUR RESPONSE]
 ```
 
+The file now contains the full transcript through your latest turn.
+
 ### 4c. Get Gemini's Follow-up
 
 ```bash
 node .claude/scripts/ask-gemini.js respond --context-file /tmp/ask-gemini-context.md --debate-file /tmp/ask-gemini-debate.md
 ```
 
-**Read** the target file first (ignore the error if it doesn't exist), then **Write** Gemini's response to its own round file (e.g., `/tmp/ask-gemini-round-1-gemini.md`). Continue to the next round.
+The script reads the cumulative debate file, which now includes the initial review, all prior Claude turns, and all prior Gemini turns. It generates the next response with full context.
+
+**Read** `/tmp/ask-gemini-debate.md` first, then **Write** the file with the script's output appended at the end under this heading:
+
+```markdown
+## Gemini (Round N):
+
+[STDOUT FROM THE RESPOND SCRIPT]
+```
+
+Continue to the next round.
 
 **Repeat this cycle 3 times total.**
 
 ## Step 5: Generate Summary
 
-After 3 debate cycles, **Read** all 6 round files (`/tmp/ask-gemini-round-1.md` through `/tmp/ask-gemini-round-3-gemini.md`), combine their contents in order, then **Read** `/tmp/ask-gemini-debate.md` (ignore the error if it doesn't exist) and **Write** the combined content to it. Then generate the final summary:
+After 3 debate cycles, the debate file contains the complete transcript: initial review, then 3 rounds of Claude/Gemini exchanges. Generate the final summary:
 
 ```bash
 node .claude/scripts/ask-gemini.js summary --context-file /tmp/ask-gemini-context.md --debate-file /tmp/ask-gemini-debate.md

--- a/.claude/commands/ask-gpt.md
+++ b/.claude/commands/ask-gpt.md
@@ -1,5 +1,8 @@
 # Ask GPT - Automated AI Peer Review (ChatGPT)
 
+**Use this when:** Getting a structured second opinion from ChatGPT via a 3-round debate, on a plan, code change, branch, or feature.
+**Don't use this when:** You want a first-pass code review (use `/review-code`), or you want to evaluate findings from a prior debate (use `/peer-review`).
+
 You are the Lead Reviewer. Your job is to get a second opinion from ChatGPT on the user's work, engage in a constructive debate, and produce actionable recommendations.
 
 <procedure>

--- a/.claude/commands/ask-gpt.md
+++ b/.claude/commands/ask-gpt.md
@@ -32,7 +32,7 @@ Save all gathered context to a temporary file:
 
 **Read** `/tmp/ask-gpt-context.md` first (ignore the error if it doesn't exist), then **Write** the gathered context to it.
 
-## Step 3: Get Initial Review from ChatGPT
+## Step 3: Get Initial Review and Seed the Debate File
 
 Run the ask-gpt script to get ChatGPT's initial review:
 
@@ -40,17 +40,27 @@ Run the ask-gpt script to get ChatGPT's initial review:
 node .claude/scripts/ask-gpt.js review --context-file /tmp/ask-gpt-context.md --review-type [plan|code|branch|feature]
 ```
 
-Read the script output. In the next step, you'll respond to this review as the author.
+The cumulative debate file `/tmp/ask-gpt-debate.md` is built incrementally: every script call and every Claude turn gets appended to it BEFORE the next step runs. This way each `respond` call sees the full prior transcript.
+
+**Read** `/tmp/ask-gpt-debate.md` first (ignore the error if it does not exist - this is a fresh debate). Then **Write** the file with the script's output under this heading:
+
+```markdown
+## ChatGPT (Initial Review):
+
+[STDOUT FROM THE REVIEW SCRIPT]
+```
+
+Read the saved review yourself - the next step is responding to it as the author.
 
 If the script fails, show the error to the user. Common issues: missing API key in `.env.local` or environment variables, network errors, rate limits. Do not retry automatically.
 
 ## Step 4: Debate Cycle (Repeat 3 Times)
 
-For each debate cycle:
+For each debate cycle (rounds 1, 2, and 3):
 
 ### 4a. Respond to ChatGPT's Feedback
 
-As the author, respond to ChatGPT's review using this structure:
+As the author, draft a response using this structure:
 
 ```markdown
 ## Accepted
@@ -63,11 +73,9 @@ Points where I have a different perspective (with reasoning)
 Clarifications needed from the reviewer
 ```
 
-### 4b. Save the Debate History
+### 4b. Append Your Response to the Debate File
 
-Append your response to a debate file:
-
-Save each round to its own file: `/tmp/ask-gpt-round-N.md` (e.g., `/tmp/ask-gpt-round-1.md`). **Read** the target file first (ignore the error if it doesn't exist), then **Write** it:
+**Read** `/tmp/ask-gpt-debate.md` first, then **Write** the file with your response appended at the end under this heading (where N is the current round number):
 
 ```markdown
 ## Claude (Round N):
@@ -75,19 +83,31 @@ Save each round to its own file: `/tmp/ask-gpt-round-N.md` (e.g., `/tmp/ask-gpt-
 [YOUR RESPONSE]
 ```
 
+The file now contains the full transcript through your latest turn.
+
 ### 4c. Get ChatGPT's Follow-up
 
 ```bash
 node .claude/scripts/ask-gpt.js respond --context-file /tmp/ask-gpt-context.md --debate-file /tmp/ask-gpt-debate.md
 ```
 
-**Read** the target file first (ignore the error if it doesn't exist), then **Write** ChatGPT's response to its own round file (e.g., `/tmp/ask-gpt-round-1-gpt.md`). Continue to the next round.
+The script reads the cumulative debate file, which now includes the initial review, all prior Claude turns, and all prior ChatGPT turns. It generates the next response with full context.
+
+**Read** `/tmp/ask-gpt-debate.md` first, then **Write** the file with the script's output appended at the end under this heading:
+
+```markdown
+## ChatGPT (Round N):
+
+[STDOUT FROM THE RESPOND SCRIPT]
+```
+
+Continue to the next round.
 
 **Repeat this cycle 3 times total.**
 
 ## Step 5: Generate Summary
 
-After 3 debate cycles, **Read** all 6 round files (`/tmp/ask-gpt-round-1.md` through `/tmp/ask-gpt-round-3-gpt.md`), combine their contents in order, then **Read** `/tmp/ask-gpt-debate.md` (ignore the error if it doesn't exist) and **Write** the combined content to it. Then generate the final summary:
+After 3 debate cycles, the debate file contains the complete transcript: initial review, then 3 rounds of Claude/ChatGPT exchanges. Generate the final summary:
 
 ```bash
 node .claude/scripts/ask-gpt.js summary --context-file /tmp/ask-gpt-context.md --debate-file /tmp/ask-gpt-debate.md

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,5 +1,8 @@
 # Create Issue
 
+**Use this when:** Capturing a short bug, feature, or improvement on GitHub - the WHAT, not the HOW.
+**Don't use this when:** You need to plan implementation details (use `/explore` and `/create-plan`).
+
 Hey! I'm ready to help you capture this issue. What's on your mind? Just give me:
 
 - **What's the issue/feature** (1-2 sentences)

--- a/.claude/commands/create-plan.md
+++ b/.claude/commands/create-plan.md
@@ -1,5 +1,8 @@
 # Plan Creation Stage
 
+**Use this when:** Turning a fully-explored idea into a step-by-step implementation plan with status tracking.
+**Don't use this when:** The idea is not yet scoped (use `/explore` first), or the change is small enough that a plan would just be ceremony.
+
 Based on our full exchange, produce a markdown plan document.
 
 ## Worktree Check

--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -1,5 +1,8 @@
 # Update Documentation Task
 
+**Use this when:** Updating README, CLAUDE.md, CHANGELOG, LESSONS, or INDEX after code changes have shipped.
+**Don't use this when:** You only need in-code docstrings or comments (just edit the code directly), or you are mid-implementation - wait until the work is done.
+
 You are updating documentation after code changes.
 
 ## Primary Documentation Files

--- a/.claude/commands/execute.md
+++ b/.claude/commands/execute.md
@@ -1,5 +1,8 @@
 # Execute Plan
 
+**Use this when:** Building a feature step-by-step against an existing plan in `plans/PLAN-*.md`.
+**Don't use this when:** No plan exists yet (use `/create-plan` first), or the change is a one-line fix that does not need a plan.
+
 Now implement precisely as planned, in full.
 
 ## Implementation Requirements

--- a/.claude/commands/explore.md
+++ b/.claude/commands/explore.md
@@ -1,5 +1,8 @@
 # Initial Exploration Stage
 
+**Use this when:** Starting a new feature, strategic question, or refactor that needs scoping or vision-level thinking before any code is written.
+**Don't use this when:** You already have a clear plan (use `/create-plan`) or you are debugging a specific bug (use `/pair-debug`).
+
 <rules>
 Your task is NOT to implement this yet, but to fully understand and prepare.
 </rules>

--- a/.claude/commands/package-review.md
+++ b/.claude/commands/package-review.md
@@ -1,5 +1,8 @@
 # Package Code for Review
 
+**Use this when:** Bundling code into a single markdown file for external AI review (paste into ChatGPT or Gemini directly).
+**Don't use this when:** You want an automated multi-round debate (use `/ask-gpt` or `/ask-gemini`).
+
 Create a single markdown file containing all code and context needed for external peer review (ChatGPT, Gemini, etc.).
 
 ## How It Works

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -45,9 +45,12 @@ If it fails because the branch name is taken, increment N and try again.
 
 ### Step 5: Install dependencies
 
-If `package.json` exists in the worktree root, run: `npm install --prefix .claude/worktrees/worktree-N`
+Install host project deps and toolkit deps separately. The toolkit's deps live in `.claude/scripts/` (post-v4.3) and need their own install - without it, `/review-browser`, `/ask-gpt`, and `/ask-gemini` will not work in the new worktree.
 
-If there is no `package.json`, skip this step. If npm install fails, warn the user but do NOT stop. The worktree is still usable for non-debate work.
+1. **Host project deps** - if `package.json` exists at the worktree root, run: `npm install --prefix .claude/worktrees/worktree-N`. Skip if there is no host package.json.
+2. **Toolkit deps** - if `.claude/scripts/package.json` exists in the worktree, run: `npm install --prefix .claude/worktrees/worktree-N/.claude/scripts`. Skip if there is no toolkit package.json (older v4.2 layouts kept toolkit deps at the host root).
+
+If either install fails, warn the user but do NOT stop. The worktree is still usable for general work, but the affected toolkit features will not run until the missing deps are installed manually.
 
 ### Step 6: Copy environment
 
@@ -68,10 +71,11 @@ Print a clear summary using this format:
 ```
 Worktree ready!
 
-  Path:    /full/absolute/path/to/.claude/worktrees/worktree-N
-  Branch:  worktree-N
-  npm:     installed (or: failed - run manually / skipped - no package.json)
-  .env:    copied (or: skipped - not found / already exists)
+  Path:         /full/absolute/path/to/.claude/worktrees/worktree-N
+  Branch:       worktree-N
+  Host npm:     installed (or: failed - run manually / skipped - no package.json)
+  Toolkit npm:  installed (or: failed - run manually / skipped - no .claude/scripts/package.json)
+  .env:         copied (or: skipped - not found / already exists)
 
 Next steps:
   1. Open that path in a new Cursor window

--- a/.claude/skills/learning-opportunity/SKILL.md
+++ b/.claude/skills/learning-opportunity/SKILL.md
@@ -10,6 +10,9 @@ allowed-tools:
 
 # Learning Opportunity
 
+**Use this when:** You hit an unfamiliar pattern, framework, or concept and want to pause development to understand it at three levels of depth.
+**Don't use this when:** You are debugging a specific bug (use `/pair-debug`) or reviewing code quality (use `/review-code`).
+
 Pause development mode. I want to understand something better.
 
 ## Teaching Approach


### PR DESCRIPTION
## Summary

Fixes the four Warn-level findings surfaced by the `/review-commands` audit committed in [`reports/review-commands-2026-05-03.md`](reports/review-commands-2026-05-03.md) (issue #93).

- **R1 + R2** ([8f57f70](../../commit/8f57f70)) - `/ask-gpt` and `/ask-gemini` debate flow rewritten to build a single cumulative debate file incrementally instead of only at the end. Each `respond` call now sees the complete prior transcript, and the initial review is preserved in the saved transcript. R2 (initial review never saved) is included because the proper fix for R1 requires the initial review in the debate file for round 1's `respond` to have meaningful context.
- **R3** ([6565ae6](../../commit/6565ae6)) - `/worktree` now installs both host project deps and toolkit deps. Pre-fix, fresh worktrees silently lacked `.claude/scripts/node_modules` after the v4.3 quarantine, so `/review-browser`, `/ask-gpt`, and `/ask-gemini` would fail until the user knew to install toolkit deps separately. Step 7's printed summary updated to show both install statuses.
- **R4** ([72e2211](../../commit/72e2211)) - "Use this when / Don't use this when" markers added to nine commands and skills that lacked them: `explore`, `create-plan`, `execute`, `document`, `ask-gpt`, `ask-gemini`, `create-issue`, `package-review`, and `learning-opportunity`. Each block names a sibling command for the "Don't use" cross-reference.

10 files changed, 97 insertions, 26 deletions. Three thematically-pure commits.

## What's NOT in this PR

- **R5-R10** (the six Suggest-level polish items from the audit report) - kept out per scope.
- **`.claude/settings.json` change** - the harness auto-added `Skill(review-commands)` permissions during the audit run. Per the project convention (LESSONS.md), those permissions belong in `.claude/settings.local.json`. Left for the user to move/revert.

## Test plan

- [ ] Read the diff in `ask-gpt.md` and `ask-gemini.md` and confirm Steps 3-5 read as a coherent flow (no per-round files, single cumulative debate file).
- [ ] Trigger `/ask-gpt` on a small change to verify rounds 2 and 3 actually receive prior context (compare to a baseline run on `main` where they would not).
- [ ] Run `/worktree` and confirm both host npm and toolkit npm install messages print in the Step 7 summary.
- [ ] Type each command name in the slash menu and confirm the new markers appear at the top of the prompt.
- [ ] Verify that the report at `reports/review-commands-2026-05-03.md` is unchanged (it documents these findings, should not be edited as part of the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)